### PR TITLE
Remove extra semicolon in CSS font import

### DIFF
--- a/css/01-fonts.css
+++ b/css/01-fonts.css
@@ -1,1 +1,1 @@
-@import "https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;500;700;";
+@import "https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;500;700";


### PR DESCRIPTION
Fonts do not load without this and causes an error in the console. Are we loading the font from multiple places? We should only load it once if we can help it.