### PR TITLE
Remove [Indico] prefix from platform emails

### DIFF
--- a/templates/core/emails/base.html
+++ b/templates/core/emails/base.html
@@ -1,0 +1,2 @@
+{% extends '~emails/base.html' %}
+{% block subject_prefix %}{% endblock %}

--- a/templates/core/emails/base.txt
+++ b/templates/core/emails/base.txt
@@ -1,0 +1,2 @@
+{% extends '~emails/base.txt' %}
+{% block subject_prefix %}{% endblock %}


### PR DESCRIPTION
When various emails are sent, they have `[Indico]` in their prefix. I don't think this is necessary, so I am removing it. Unfortunately Indico is hardcoded in quite a few places, so it would likely be a larger project to remove its mention in all emails and I'm going with this for now.